### PR TITLE
fix: bump sentencepiece and Pillow to resolve Dependabot security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 transformers
-sentencepiece==0.1.91
+sentencepiece>=0.1.97
 pytesseract
-Pillow
+Pillow>=10.3.0


### PR DESCRIPTION
- sentencepiece: pinned 0.1.91 → >=0.1.97 (CVE-2023-29795, CVE-2023-29946)
- Pillow: unpinned → >=10.3.0 to exclude all known CVEs