### PR TITLE
fix: tighten sentencepiece and Pillow bounds to clear all Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 transformers
-sentencepiece>=0.1.97
+sentencepiece>=0.2.1
 pytesseract
-Pillow>=10.3.0
+Pillow>=12.3.0


### PR DESCRIPTION
## Summary
- `sentencepiece`: `>=0.1.97` → `>=0.2.1` (fixes alerts #61, #62 — heap buffer overflows)
- `Pillow`: `>=10.3.0` → `>=12.3.0` (fixes alerts #55, #56, #63–74 — multiple CVEs including 1 critical)

## Test plan
- [ ] Confirm all 16 open Dependabot alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)